### PR TITLE
Added Jedi-Vim and updated README

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule ".vim/bundle/vim-markdown"]
 	path = .vim/bundle/vim-markdown
 	url = https://github.com/plasticboy/vim-markdown.git
+[submodule ".vim/bundle/jedi-vim"]
+	path = .vim/bundle/jedi-vim
+	url = git://github.com/davidhalter/jedi-vim.git

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ folder as _vimrc). - NEEDS TESTING
 * git
 * pip
 * vim
+ * vim-nox (Debian users)
 * curl
 
 ## Installation Instructions
@@ -41,6 +42,7 @@ The update.sh file will update the project, plugins and color schemes in use (li
 * Vim Isort - https://github.com/fisadev/vim-isort
 * Ps1.vim - https://github.com/PProvost/vim-ps1
 * Vim Markdown - https://github.com/plasticboy/vim-markdown
+* Jedi-VIM - https://github.com/davidhalter/jedi-vim
 
 ## List of color schemes
 * Molokai Color Scheme - https://github.com/tomasr/molokai


### PR DESCRIPTION
Updated README to indicate the need to install vim-nox for Debian users (update script doesn't check for this). 

Added support for jedi-vim; ran this with seemingly no conflicts with the other python related modules. 